### PR TITLE
[HOPSWORKS-1405-amend] Run default recipe after consul::master for single node installations

### DIFF
--- a/Karamelfile
+++ b/Karamelfile
@@ -4,6 +4,7 @@ dependencies:
       - kagent::install
   - recipe: kzookeeper::default
     global:
+      - consul::master
       - consul::slave
       - kagent::default
 


### PR DESCRIPTION
https://logicalclocks.atlassian.net/browse/HOPSWORKS-1405

In single node installations there isn't `consul::slave` recipe, only `consul::master`