### PR TITLE
[CLOUD-605] Increase waiter timeout

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -236,7 +236,7 @@ end
 bash 'wait-for-zookeeper' do
   user node['kzookeeper']['user']
   group node['kzookeeper']['group']
-  timeout 250
+  timeout 1810
   code <<-EOH
       #{node['kzookeeper']['bin_dir']}/waiter.sh
   EOH

--- a/templates/default/waiter.sh.erb
+++ b/templates/default/waiter.sh.erb
@@ -10,7 +10,7 @@ do
     fi
     echo "ZooKeeper service is not running/healthy"
     let i++
-    if [ $i -gt 100 ]
+    if [ $i -gt 900 ]
     then
         echo "Exhausted all retries"
         exit 1


### PR DESCRIPTION
Increase waiter timeout because default recipe on different machines may run with a few minutes in between