### PR TITLE
[CLOUD-605] Wait only during upgrades

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -240,6 +240,7 @@ bash 'wait-for-zookeeper' do
   code <<-EOH
       #{node['kzookeeper']['bin_dir']}/waiter.sh
   EOH
+  only_if { conda_helpers.is_upgrade }
 end
 
 # This is idempotent and succeeds even if the node doesn't exists


### PR DESCRIPTION
During first installation waiting for the cluster to be health - quorum - is susceptible to timing issues 